### PR TITLE
Update Quarkus and Roq to latest compatible versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ nb-configuration.xml
 /.quarkus/cli/plugins/
 # TLS Certificates
 .certs/
+
+# Node modules (Web Bundler)
+node_modules/

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-        <quarkus.platform.version>3.17.8</quarkus.platform.version>
+        <quarkus.platform.version>3.29.4</quarkus.platform.version>
         <skipITs>true</skipITs>
         <surefire-plugin.version>3.5.0</surefire-plugin.version>
     </properties>
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq</artifactId>
-            <version>1.2.0</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>io.quarkiverse.roq</groupId>
             <artifactId>quarkus-roq-theme-default</artifactId>
-            <version>1.2.0</version>
+            <version>2.0.4</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>


### PR DESCRIPTION
Updated Quarkus from 3.17.8 to 3.29.4 and Roq from 1.2.0 to 2.0.4. Added node_modules/ to .gitignore for Web Bundler compatibility.